### PR TITLE
Update stack trace implementation to use github.com/goaux/stacktrace/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goaux/results
 
 go 1.20
 
-require github.com/goaux/stacktrace v1.0.3
+require github.com/goaux/stacktrace/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goaux/stacktrace v1.0.3 h1:KUIt4D6lTIpmyrVyhQtzYSvtDxN1tigNcH3xt1BSYzo=
-github.com/goaux/stacktrace v1.0.3/go.mod h1:JphATKwXM5g3x3y7mvb0zbxUJYzHlkMYuGPntIRW/LA=
+github.com/goaux/stacktrace/v2 v2.2.0 h1:0m2qM+ooPcqv7/1S+ns7dNDRAinRptNV8OBySijkvow=
+github.com/goaux/stacktrace/v2 v2.2.0/go.mod h1:WT0j+ibEaqyL8LiVI69FlMcGirtjCg92nXj/YT/vfCM=

--- a/maybe1.go
+++ b/maybe1.go
@@ -1,6 +1,6 @@
 package results
 
-import "github.com/goaux/stacktrace"
+import "github.com/goaux/stacktrace/v2"
 
 // Maybe1 holds a value and an error
 type Maybe1[T any] struct {

--- a/maybe2.go
+++ b/maybe2.go
@@ -1,6 +1,6 @@
 package results
 
-import "github.com/goaux/stacktrace"
+import "github.com/goaux/stacktrace/v2"
 
 // Maybe2 holds two values and an error
 type Maybe2[T0, T1 any] struct {

--- a/maybe3.go
+++ b/maybe3.go
@@ -1,6 +1,6 @@
 package results
 
-import "github.com/goaux/stacktrace"
+import "github.com/goaux/stacktrace/v2"
 
 // Maybe3 holds three values and an error
 type Maybe3[T0, T1, T2 any] struct {

--- a/must.go
+++ b/must.go
@@ -1,6 +1,6 @@
 package results
 
-import "github.com/goaux/stacktrace"
+import "github.com/goaux/stacktrace/v2"
 
 // Must panics if the error is non-nil.
 // It's useful for operations that should never fail during normal execution.


### PR DESCRIPTION
- Switched from the previous version of the stacktrace package to v2 in order to leverage new features and improvements.
- Ensured backward compatibility with versions v1.1.0 and above of github.com/goaux/stacktrace, maintaining seamless integration with existing functionalities.