### PR TITLE
feat: Implement `ErrorIs` for multiple error targets

### DIFF
--- a/error.go
+++ b/error.go
@@ -21,3 +21,27 @@ func ErrorAs[T any](err error) (target T, ok bool) {
 	ok = errors.As(err, &target)
 	return
 }
+
+// ErrorIs returns true if the error or any error in its chain
+// matches any of the target errors. It returns false otherwise.
+//
+// It iterates through the target errors and uses [errors.Is] to
+// determine if the input error or any error in its chain matches
+// any of them.
+//
+// Parameters:
+//
+//	err: The error to check.
+//	target: A variadic list of target errors to compare against.
+//
+// Returns:
+//
+//	True if the error matches any of the target errors, false otherwise.
+func ErrorIs(err error, target ...error) bool {
+	for _, e := range target {
+		if errors.Is(err, e) {
+			return true
+		}
+	}
+	return false
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,8 +1,10 @@
 package results_test
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
+	"strconv"
 	"testing"
 
 	"github.com/goaux/results"
@@ -41,4 +43,50 @@ func TestErrorAs(t *testing.T) {
 			t.Error("should be nil")
 		}
 	})
+}
+
+func TestErrorIs(t *testing.T) {
+	Err1 := errors.New("Err1")
+	Err2 := errors.New("Err2")
+	Err3 := errors.New("Err3")
+
+	WErr1 := fmt.Errorf("WErr1 %w", Err1)
+	WErr2 := fmt.Errorf("WErr2 %w", Err2)
+	WErr3 := fmt.Errorf("WErr3 %w", Err3)
+
+	WErr12 := fmt.Errorf("WErr12 %w %w", Err1, Err2)
+
+	tests := []struct {
+		err    error
+		target []error
+		expect bool
+	}{
+		{Err1, []error{}, false},
+		{Err1, []error{Err1}, true},
+		{Err1, []error{Err2}, false},
+		{Err1, []error{Err1, Err2}, true},
+		{Err2, []error{Err1, Err2}, true},
+		{Err3, []error{Err1, Err2}, false},
+
+		{WErr1, []error{}, false},
+		{WErr1, []error{Err1}, true},
+		{WErr1, []error{Err2}, false},
+		{WErr1, []error{Err1, Err2}, true},
+		{WErr2, []error{Err1, Err2}, true},
+		{WErr3, []error{Err1, Err2}, false},
+
+		{WErr12, []error{}, false},
+		{WErr12, []error{Err1}, true},
+		{WErr12, []error{Err2}, true},
+		{WErr12, []error{Err1, Err2}, true},
+		{WErr12, []error{Err3}, false},
+	}
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual := results.ErrorIs(tc.err, tc.target...)
+			if actual != tc.expect {
+				t.Errorf("actual=%v expect=%v", actual, tc.expect)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds an `ErrorIs` function that checks if an error matches any of the provided target errors. This provides more flexibility than the standard `errors.Is` when needing to check against multiple potential error types. The implementation iterates through the target errors and returns true if a match is found using `errors.Is`.

Closes #5 